### PR TITLE
Issue 570 - CI process improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: python
 install: 
         - pip3 install -r requirements.txt -r requirements-extra.txt
-script: tox -vv
+script: tox
 matrix:
         include:
                 - os: "linux"
@@ -24,3 +24,5 @@ matrix:
                   before_script:
                           - pip install -r requirements-windows.txt
                           - python build.py
+                  script:
+                          - tox -e WINDOWS

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,10 @@ matrix:
                 - os: "linux"
                   dist: "xenial"
                   python: "3.7"
+                - os: "windows"
+                  language: shell
+                  python: "3.7"
+                  env: "PATH=/c/python37:/c/python37/Scripts:$PATH"
+                  before_install:
+                          - choco install python make
+                          - cp /c/python37/python.exe /c/python37/python3.exe

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: python
 install: pip3 install tox-travis
-script: tox
+script: tox -vv
 matrix:
         include:
                 - os: "linux"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,5 @@ matrix:
                   before_install:
                           - choco install python make
                           - cp /c/python37/python.exe /c/python37/python3.exe
+                  before_script:
+                          - python build.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
                           - choco install python make
                           - cp /c/python37/python.exe /c/python37/python3.exe
                   before_script:
-                          - pip install -r requirements-windows.txt
-                          - python build.py
+                          - pip3 install -r requirements-windows.txt
+                          - python3 build.py
                   script:
                           - tox -e WINDOWS

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 sudo: false
-dist: xenial
 language: python
-python:
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7"
-install: pip install tox-travis
+install: pip3 install tox-travis
 script: tox
-
+matrix:
+        include:
+                - os: "linux"
+                  dist: "xenial"
+                  python: "3.5"
+                - os: "linux"
+                  dist: "xenial"
+                  python: "3.6"
+                - os: "linux"
+                  dist: "xenial"
+                  python: "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: python
-install: pip3 install tox-travis
+install: 
+        - pip3 install -r requirements.txt -r requirements-extra.txt
 script: tox -vv
 matrix:
         include:
@@ -21,4 +22,5 @@ matrix:
                           - choco install python make
                           - cp /c/python37/python.exe /c/python37/python3.exe
                   before_script:
+                          - pip install -r requirements-windows.txt
                           - python build.py

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -1,4 +1,4 @@
 pytest>=2.0.0,<3.0
 pytest-monkeyplus>=1.0.0
 flake8
-
+tox-travis

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34,py35,py36
+envlist = py35,py36,py37
 skipsdist = True
 skip_missing_interpreters = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,10 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements-extra.txt
 
+[testenv:WINDOWS]
+deps =
+    -r{toxinidir}/requirements-windows.txt
+
 [flake8]
 exclude = .tox,env,build,hscommon,qtlib,cocoalib,cocoa,help,./qt/dg_rc.py,qt/run_template.py,cocoa/run_template.py,./run.py,./pkg
 max-line-length = 120

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ deps =
 
 [testenv:WINDOWS]
 deps =
+    {[testenv]deps}
     -r{toxinidir}/requirements-windows.txt
 
 [flake8]


### PR DESCRIPTION
These changes bring Windows into the build system.  When triggered (by github push) travis-ci will kick off 4 jobs in parallel-- Testing Ubuntu Xenial with Python 3.5, 3.6, and 3.7, plus an early-access Windows VM with python 3.7.

On Linux, the pytest results are passing as expected (since nothing really changed for the Linux builds).

On Windows, tox is behaving oddly-- it isn't recognizing any tests or really anything at all to do, it just says Congratuations.  However, the build does critically depend on successful "python3 build.py" so in principle this should be at least a test of compiling the modules.

Additional work could add a after_success task to call package.py and to save the resulting artifact for more testing.

--Joe