### PR TITLE
Makefile compatibility with macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PREFIX ?= /usr/local
 # - compile generates .pyd instead of .so
 # - venv with --sytem-site-packages has issues on windows as well...
 
-ifeq ($(shell uname -o), Msys)
+ifeq ($(OSTYPE), msys)
 	BIN = Scripts
 	SO = *.pyd
 	VENV_OPTIONS = 


### PR DESCRIPTION
macOS ships BSD uname, which has no option "-o", so make fails. Change this to use bash ${OSTYPE} instead, which is platform independent.