### PR TITLE
Add a preference option to disable bold font on reference row.

### DIFF
--- a/qt/preferences.py
+++ b/qt/preferences.py
@@ -30,6 +30,7 @@ class Preferences(PreferencesBase):
             self.language = trans.installed_lang
 
         self.tableFontSize = get("TableFontSize", self.tableFontSize)
+        self.reference_bold_font = get('ReferenceBoldFont', self.reference_bold_font)
         self.resultWindowIsMaximized = get(
             "ResultWindowIsMaximized", self.resultWindowIsMaximized
         )
@@ -65,6 +66,7 @@ class Preferences(PreferencesBase):
         self.language = trans.installed_lang if trans.installed_lang else ""
 
         self.tableFontSize = QApplication.font().pointSize()
+        self.reference_bold_font = True
         self.resultWindowIsMaximized = False
         self.resultWindowRect = None
         self.directoriesWindowRect = None
@@ -97,6 +99,7 @@ class Preferences(PreferencesBase):
         set_("Language", self.language)
 
         set_("TableFontSize", self.tableFontSize)
+        set_('ReferenceBoldFont', self.reference_bold_font)
         set_("ResultWindowIsMaximized", self.resultWindowIsMaximized)
         self.set_rect("ResultWindowRect", self.resultWindowRect)
         self.set_rect("DirectoriesWindowRect", self.directoriesWindowRect)

--- a/qt/preferences_dialog.py
+++ b/qt/preferences_dialog.py
@@ -117,6 +117,8 @@ class PreferencesDialogBase(QDialog):
         self.widgetsVLayout.addLayout(
             horizontalWrap([self.fontSizeLabel, self.fontSizeSpinBox, None])
         )
+        self._setupAddCheckbox("reference_bold_font", tr("Bold font for reference."))
+        self.widgetsVLayout.addWidget(self.reference_bold_font)
         self.languageLabel = QLabel(tr("Language:"), self)
         self.languageComboBox = QComboBox(self)
         for lang in self.supportedLanguages:
@@ -187,6 +189,7 @@ class PreferencesDialogBase(QDialog):
         setchecked(self.removeEmptyFoldersBox, prefs.remove_empty_folders)
         setchecked(self.ignoreHardlinkMatches, prefs.ignore_hardlink_matches)
         setchecked(self.debugModeBox, prefs.debug_mode)
+        setchecked(self.reference_bold_font, prefs.reference_bold_font)
         self.copyMoveDestinationComboBox.setCurrentIndex(prefs.destination_type)
         self.customCommandEdit.setText(prefs.custom_command)
         self.fontSizeSpinBox.setValue(prefs.tableFontSize)
@@ -206,6 +209,7 @@ class PreferencesDialogBase(QDialog):
         prefs.remove_empty_folders = ischecked(self.removeEmptyFoldersBox)
         prefs.ignore_hardlink_matches = ischecked(self.ignoreHardlinkMatches)
         prefs.debug_mode = ischecked(self.debugModeBox)
+        prefs.reference_bold_font = ischecked(self.reference_bold_font)
         prefs.destination_type = self.copyMoveDestinationComboBox.currentIndex()
         prefs.custom_command = str(self.customCommandEdit.text())
         prefs.tableFontSize = self.fontSizeSpinBox.value()

--- a/qt/results_model.py
+++ b/qt/results_model.py
@@ -25,6 +25,7 @@ class ResultsModel(Table):
         view.verticalHeader().setDefaultSectionSize(fm.height() + 2)
 
         app.willSavePrefs.connect(self.appWillSavePrefs)
+        self.prefs = app.prefs
 
     def _getData(self, row, column, role):
         if column.name == "marked":
@@ -40,9 +41,9 @@ class ResultsModel(Table):
             elif row.is_cell_delta(column.name):
                 return QBrush(QColor(255, 142, 40))  # orange
         elif role == Qt.FontRole:
-            isBold = row.isref
             font = QFont(self.view.font())
-            font.setBold(isBold)
+            if self.prefs.reference_bold_font:
+                font.setBold(row.isref)
             return font
         elif role == Qt.EditRole:
             if column.name == "name":


### PR DESCRIPTION
As requested in #314, implements a tick box to enable or disable bold font on reference items, which makes it a bit easier to read when filenames are exactly the same (the bold font makes them look different, even though they are not). 