### PR TITLE
Fix row trimming

### DIFF
--- a/qt/details_table.py
+++ b/qt/details_table.py
@@ -52,6 +52,7 @@ class DetailsTable(QTableView):
         self.setAlternatingRowColors(True)
         self.setSelectionBehavior(QTableView.SelectRows)
         self.setShowGrid(False)
+        self.setWordWrap(False)
 
     def setModel(self, model):
         QTableView.setModel(self, model)

--- a/qt/result_window.py
+++ b/qt/result_window.py
@@ -327,6 +327,7 @@ class ResultWindow(QMainWindow):
         self.resultsView.setSelectionMode(QAbstractItemView.ExtendedSelection)
         self.resultsView.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.resultsView.setSortingEnabled(True)
+        self.resultsView.setWordWrap(False)
         self.resultsView.verticalHeader().setVisible(False)
         h = self.resultsView.horizontalHeader()
         h.setHighlightSections(False)


### PR DESCRIPTION
Prevents aggressive trimming of text in details dialog & result dialog rows. The word wrapping was enabled by default, which resulted in truncated text being displayed below the row (out of bounds, hence hidden).

As per #654. 