### PR TITLE
Add shortcut description to mark selected action

### DIFF
--- a/qt/result_window.py
+++ b/qt/result_window.py
@@ -169,7 +169,7 @@ class ResultWindow(QMainWindow):
             ),
             (
                 "actionMarkSelected",
-                "Space",
+                Qt.Key_Space,
                 "",
                 tr("Mark Selected"),
                 self.markSelectedTriggered,

--- a/qt/result_window.py
+++ b/qt/result_window.py
@@ -169,7 +169,7 @@ class ResultWindow(QMainWindow):
             ),
             (
                 "actionMarkSelected",
-                "",
+                "Space",
                 "",
                 tr("Mark Selected"),
                 self.markSelectedTriggered,


### PR DESCRIPTION
As per #641 add missing shortcut description to the mark selected action.
Technically this is not the description but an actual shortcut (setup by [createActions()](https://github.com/arsenetar/dupeguru/blob/master/qtlib/util.py#L70), and according to [PyQt5 documentation](https://www.riverbankcomputing.com/static/Docs/PyQt5/api/qtwidgets/qaction.html) SetShortcut() can take a string).
However, the [spacePressed](https://github.com/arsenetar/dupeguru/blob/master/qt/result_window.py#L471) event is what is actually called, so either the QAction's shortcut doesn't really work here, or they are both called (which doesn't seem likely since marking seems to work just fine still).