### PR TITLE
Fix packaging on *ubuntu 20.04 (more specifically python version >=3.8)

### DIFF
--- a/package.py
+++ b/package.py
@@ -212,7 +212,11 @@ def main():
         package_windows()
     else:
         if not args.arch_pkg:
-            distname, _, _ = platform.dist()
+            try:
+              distname, _, _ = platform.dist()
+            except AttributeError:
+              import distro
+              distname, _, _ = distro.linux_distribution(full_distribution_name=False)
         else:
             distname = "arch"
         if distname == "arch":

--- a/package.py
+++ b/package.py
@@ -90,7 +90,7 @@ def package_debian_distribution(distribution):
     )
     shutil.copy(op.join("images", "dgse_logo_128.png"), srcpath)
     os.chdir(destpath)
-    cmd = "dpkg-buildpackage -S -us -uc"
+    cmd = "dpkg-buildpackage -F -us -uc"
     os.system(cmd)
     os.chdir("../..")
 

--- a/package.py
+++ b/package.py
@@ -12,6 +12,7 @@ import shutil
 import json
 from argparse import ArgumentParser
 import platform
+import distro
 import re
 
 from hscommon.build import (
@@ -212,11 +213,7 @@ def main():
         package_windows()
     else:
         if not args.arch_pkg:
-            try:
-              distname, _, _ = platform.dist()
-            except AttributeError:
-              import distro
-              distname, _, _ = distro.linux_distribution(full_distribution_name=False)
+            distname = distro.id()
         else:
             distname = "arch"
         if distname == "arch":

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Send2Trash>=1.3.0
 sphinx>=1.2.2
 polib>=1.0.4
 hsaudiotag3k>=1.1.3
+distro>=1.5.0


### PR DESCRIPTION
Since the PPA did not have a package for Ubuntu 20.04, I tried creating it myself and ran into an attribute error (no platform.dist() function).

The following changes fix it and might help with issue #484.

Of course, maybe it would be better to check for the python version or use another way instead of a try/except statement. But at least try/except should be robust.

I also changed the option to dpkg-buildpackage, so it actually makes the .deb packages I wanted.

I split my changes into two commits, depending on whether or not the second change is desirable.

The package can be built using the instructions from README.md:
`$ bash -c "python3 -m venv --system-site-packages env && source env/bin/activate && pip install -r requirements.txt && python3 build.py --clean && python3 package.py"
`