### PR TITLE
Fix standard mode folder comparison view generating "---" in results table

### DIFF
--- a/core/app.py
+++ b/core/app.py
@@ -537,10 +537,15 @@ class DupeGuru(Broadcaster):
             return empty_data()
         try:
             return dupe.get_display_info(group, delta)
+        except NotImplementedError as e:
+            logging.warning(
+                "Exception (type: %s) on GetDisplayInfo for %s: %s",
+                type(e), str(dupe.path), str(e))
+            return se.fs.Folder.get_display_info(dupe, group, delta)
         except Exception as e:
             logging.warning(
-                "Exception on GetDisplayInfo for %s: %s", str(dupe.path), str(e)
-            )
+                "Exception (type: %s) on GetDisplayInfo for %s: %s",
+                type(e), str(dupe.path), str(e))
             return empty_data()
 
     def invoke_custom_command(self):

--- a/core/app.py
+++ b/core/app.py
@@ -259,7 +259,7 @@ class DupeGuru(Broadcaster):
 
     def _create_file(self, path):
         # We add fs.Folder to fileclasses in case the file we're loading contains folder paths.
-        return fs.get_file(path, self.fileclasses + [se.fs.Folder] + [fs.Folder])
+        return fs.get_file(path, self.fileclasses + [se.fs.Folder])
 
     def _get_file(self, str_path):
         path = Path(str_path)

--- a/core/app.py
+++ b/core/app.py
@@ -259,7 +259,7 @@ class DupeGuru(Broadcaster):
 
     def _create_file(self, path):
         # We add fs.Folder to fileclasses in case the file we're loading contains folder paths.
-        return fs.get_file(path, self.fileclasses + [fs.Folder])
+        return fs.get_file(path, self.fileclasses + [se.fs.Folder] + [fs.Folder])
 
     def _get_file(self, str_path):
         path = Path(str_path)
@@ -537,11 +537,6 @@ class DupeGuru(Broadcaster):
             return empty_data()
         try:
             return dupe.get_display_info(group, delta)
-        except NotImplementedError as e:
-            logging.warning(
-                "Exception (type: %s) on GetDisplayInfo for %s: %s",
-                type(e), str(dupe.path), str(e))
-            return se.fs.Folder.get_display_info(dupe, group, delta)
         except Exception as e:
             logging.warning(
                 "Exception (type: %s) on GetDisplayInfo for %s: %s",


### PR DESCRIPTION
* When loading an XML result file containing folder only, the view doesn't read the Folder attributes. 
* A NotImplementedError exception is thrown by get_display_info() since the wrong implementation is called (core.fs.Folder, instead of core.sf.fs.Folder)
* It seems that adding the corresponding type to the `fileclasses` attribute fixes the problem 
* Fix bug report #676 

WARNING: this pull request might need some more proper testing. 