### PR TITLE
Colorize details table differences, allow moving around of rows

### DIFF
--- a/qt/details_table.py
+++ b/qt/details_table.py
@@ -29,7 +29,8 @@ class DetailsModel(QAbstractTableModel):
             return None
         if role != Qt.DisplayRole:
             return None
-        column = index.column() +1
+        # Skip first value "Attribute"
+        column = index.column() + 1
         row = index.row()
         return self.model.row(row)[column]
 
@@ -60,6 +61,7 @@ class DetailsTable(QTableView):
         self.setSelectionMode(QTableView.SingleSelection)
         self.setShowGrid(False)
         self.setWordWrap(False)
+        self.setCornerButtonEnabled(False)
 
     def setModel(self, model):
         QTableView.setModel(self, model)
@@ -73,7 +75,7 @@ class DetailsTable(QTableView):
         vheader = self.verticalHeader()
         vheader.setVisible(True)
         vheader.setDefaultSectionSize(18)
-        # FIXME hardcoded value is not ideal, perhaps resize to contents once first?
+        # hardcoded value above is not ideal, perhaps resize to contents first?
         # vheader.setSectionResizeMode(QHeaderView.ResizeToContents)
         vheader.setSectionResizeMode(QHeaderView.Fixed)
         vheader.setSectionsMovable(True)

--- a/qt/details_table.py
+++ b/qt/details_table.py
@@ -13,7 +13,7 @@ from hscommon.trans import trget
 
 tr = trget("ui")
 
-HEADER = [tr("Attribute"), tr("Selected"), tr("Reference")]
+HEADER = [tr("Selected"), tr("Reference")]
 
 
 class DetailsModel(QAbstractTableModel):
@@ -29,7 +29,7 @@ class DetailsModel(QAbstractTableModel):
             return None
         if role != Qt.DisplayRole:
             return None
-        column = index.column()
+        column = index.column() +1
         row = index.row()
         return self.model.row(row)[column]
 
@@ -40,6 +40,12 @@ class DetailsModel(QAbstractTableModel):
             and section < len(HEADER)
         ):
             return HEADER[section]
+        elif (
+            orientation == Qt.Vertical
+            and role == Qt.DisplayRole
+            and section < self.model.row_count()
+        ):
+            return self.model.row(section)[0]
         return None
 
     def rowCount(self, parent):
@@ -51,6 +57,7 @@ class DetailsTable(QTableView):
         QTableView.__init__(self, *args)
         self.setAlternatingRowColors(True)
         self.setSelectionBehavior(QTableView.SelectRows)
+        self.setSelectionMode(QTableView.SingleSelection)
         self.setShowGrid(False)
         self.setWordWrap(False)
 
@@ -61,9 +68,12 @@ class DetailsTable(QTableView):
         hheader.setHighlightSections(False)
         hheader.setStretchLastSection(False)
         hheader.resizeSection(0, 100)
-        hheader.setSectionResizeMode(0, QHeaderView.Fixed)
+        hheader.setSectionResizeMode(0, QHeaderView.Stretch)
         hheader.setSectionResizeMode(1, QHeaderView.Stretch)
-        hheader.setSectionResizeMode(2, QHeaderView.Stretch)
         vheader = self.verticalHeader()
-        vheader.setVisible(False)
+        vheader.setVisible(True)
         vheader.setDefaultSectionSize(18)
+        # FIXME hardcoded value is not ideal, perhaps resize to contents once first?
+        # vheader.setSectionResizeMode(QHeaderView.ResizeToContents)
+        vheader.setSectionResizeMode(QHeaderView.Fixed)
+        vheader.setSectionsMovable(True)

--- a/qt/details_table.py
+++ b/qt/details_table.py
@@ -32,7 +32,10 @@ class DetailsModel(QAbstractTableModel):
         column = index.column() + 1
         row = index.row()
 
-        if self.model.row(row)[0] == "Dupe Count":
+        ignored_fields = ["Dupe Count"]
+        if self.model.row(row)[0] in ignored_fields or \
+        self.model.row(row)[1] == "---" or \
+        self.model.row(row)[2] == "---":
             if role != Qt.DisplayRole:
                 return None
             return self.model.row(row)[column]
@@ -45,7 +48,6 @@ class DetailsModel(QAbstractTableModel):
             font = QFont(self.model.view.font()) # or simply QFont()
             font.setBold(True)
             return font
-
         return None # QVariant()
 
     def headerData(self, section, orientation, role):

--- a/qt/details_table.py
+++ b/qt/details_table.py
@@ -8,6 +8,7 @@
 
 from PyQt5.QtCore import Qt, QAbstractTableModel
 from PyQt5.QtWidgets import QHeaderView, QTableView
+from PyQt5.QtGui import QFont, QBrush, QColor
 
 from hscommon.trans import trget
 
@@ -27,12 +28,25 @@ class DetailsModel(QAbstractTableModel):
     def data(self, index, role):
         if not index.isValid():
             return None
-        if role != Qt.DisplayRole:
-            return None
         # Skip first value "Attribute"
         column = index.column() + 1
         row = index.row()
-        return self.model.row(row)[column]
+
+        if self.model.row(row)[0] == "Dupe Count":
+            if role != Qt.DisplayRole:
+                return None
+            return self.model.row(row)[column]
+
+        if role == Qt.DisplayRole:
+            return self.model.row(row)[column]
+        if role == Qt.ForegroundRole and self.model.row(row)[1] != self.model.row(row)[2]:
+            return QBrush(QColor(250, 20, 20))  # red
+        if role == Qt.FontRole and self.model.row(row)[1] != self.model.row(row)[2]:
+            font = QFont(self.model.view.font()) # or simply QFont()
+            font.setBold(True)
+            return font
+
+        return None # QVariant()
 
     def headerData(self, section, orientation, role):
         if (
@@ -46,6 +60,7 @@ class DetailsModel(QAbstractTableModel):
             and role == Qt.DisplayRole
             and section < self.model.row_count()
         ):
+            # Read "Attribute" cell for horizontal header
             return self.model.row(section)[0]
         return None
 
@@ -58,7 +73,7 @@ class DetailsTable(QTableView):
         QTableView.__init__(self, *args)
         self.setAlternatingRowColors(True)
         self.setSelectionBehavior(QTableView.SelectRows)
-        self.setSelectionMode(QTableView.SingleSelection)
+        self.setSelectionMode(QTableView.NoSelection)
         self.setShowGrid(False)
         self.setWordWrap(False)
         self.setCornerButtonEnabled(False)

--- a/qt/details_table.py
+++ b/qt/details_table.py
@@ -33,9 +33,9 @@ class DetailsModel(QAbstractTableModel):
         row = index.row()
 
         ignored_fields = ["Dupe Count"]
-        if self.model.row(row)[0] in ignored_fields or \
-        self.model.row(row)[1] == "---" or \
-        self.model.row(row)[2] == "---":
+        if (self.model.row(row)[0] in ignored_fields
+                or self.model.row(row)[1] == "---"
+                or self.model.row(row)[2] == "---"):
             if role != Qt.DisplayRole:
                 return None
             return self.model.row(row)[column]
@@ -45,10 +45,10 @@ class DetailsModel(QAbstractTableModel):
         if role == Qt.ForegroundRole and self.model.row(row)[1] != self.model.row(row)[2]:
             return QBrush(QColor(250, 20, 20))  # red
         if role == Qt.FontRole and self.model.row(row)[1] != self.model.row(row)[2]:
-            font = QFont(self.model.view.font()) # or simply QFont()
+            font = QFont(self.model.view.font())  # or simply QFont()
             font.setBold(True)
             return font
-        return None # QVariant()
+        return None  # QVariant()
 
     def headerData(self, section, orientation, role):
         if (


### PR DESCRIPTION
* In the details dialog, the details table view can highlight differences found between the two columns by setting the font to red and bold. 
We ignore the "Dupe count" row since it's not very useful to highlight
We also Ignore fields when they hold blank values "---" (when only one dupe is selected and displayed)
Note: this is performing string comparison for each role requested by the view. Couldn't find a more optimized way of doing this. 
* Horizontal headers are restored and replace the first "Attribute" column in order to allow moving around the rows
![2020-06-30_18-43-44](https://user-images.githubusercontent.com/12895548/86170018-cd87e300-bb1a-11ea-8c1f-7127575a53cd.png)
Perhaps it would be good to add more customization options for the user later. 
Another improvement would be to highlight only the part of a path that differs, but so far I have no idea how to efficiently do that. Might require to do changes to the underlying model.