### PR TITLE
Fix updating result window action upon creation

### DIFF
--- a/qt/app.py
+++ b/qt/app.py
@@ -283,6 +283,7 @@ class DupeGuru(QObject):
             self.resultWindow.close()
             self.resultWindow.setParent(None)
         self.resultWindow = ResultWindow(self.directories_dialog, self)
+        self.directories_dialog._updateActionsState()
         self.details_dialog = self._get_details_dialog_class()(self.resultWindow, self)
 
     def show_results_window(self):


### PR DESCRIPTION
* Result Window action was not being properly updated
after the ResultWindow had been created.
There was no way of retrieving the window after it had been closed.

This is what it looked like (now it should be enabled as soon as the result window has been instantiated once, as expected)
![2020-07-07_16-56-54](https://user-images.githubusercontent.com/12895548/86799731-8d70b500-c072-11ea-87f5-e0bbbb5dcd4a.png)
