### PR TITLE
Fix word wrap in ignore list dialog

### DIFF
--- a/qt/ignore_list_dialog.py
+++ b/qt/ignore_list_dialog.py
@@ -48,6 +48,7 @@ class IgnoreListDialog(QDialog):
         self.tableView.verticalHeader().setDefaultSectionSize(18)
         self.tableView.verticalHeader().setHighlightSections(False)
         self.tableView.verticalHeader().setVisible(False)
+        self.tableView.setWordWrap(False)
         self.verticalLayout.addWidget(self.tableView)
         self.removeSelectedButton = QPushButton(tr("Remove Selected"))
         self.clearButton = QPushButton(tr("Clear"))


### PR DESCRIPTION
This fixes word wrap being incorrectly set in the ignore list dialog, which resulted in truncated path names that would be partially hidden due to the rows not dynamically resizing themselves.