### PR TITLE
Fix error in package script for (Arch) Linux

### DIFF
--- a/package.py
+++ b/package.py
@@ -50,7 +50,7 @@ def copy_files_to_package(destpath, packages, with_so):
         return
     # include help files if they are built otherwise exit as they should be included?
     if not op.exists("build/help"):
-        print("Help files are missing. Have you run \"build.py --help\"? Exiting...")
+        print("Help files are missing. Have you run \"build.py --doc\"? Exiting...")
         return
     shutil.copytree(op.join("build", "help"), op.join(destpath, "help"))
     shutil.copytree(op.join("build", "locale"), op.join(destpath, "locale"))
@@ -165,7 +165,7 @@ def package_windows():
         return
     # include help files if they are built otherwise exit as they should be included?
     if not op.exists("build/help"):
-        print("Help files are missing. Have you run \"build.py --help\"? Exiting...")
+        print("Help files are missing. Have you run \"build.py --doc\"? Exiting...")
         return
     # create version information file from template
     try:

--- a/package.py
+++ b/package.py
@@ -43,8 +43,14 @@ def copy_files_to_package(destpath, packages, with_so):
     shutil.copy("run.py", op.join(destpath, "run.py"))
     extra_ignores = ["*.so"] if not with_so else None
     copy_packages(packages, destpath, extra_ignores=extra_ignores)
-    shutil.copytree(op.join("build", "help"), op.join(destpath, "help"))
-    shutil.copytree(op.join("build", "locale"), op.join(destpath, "locale"))
+    try:
+        shutil.copytree(op.join("build", "help"), op.join(destpath, "help"))
+    except Exception as e:
+        print(f"Warning: exception: {e}")
+    try:
+        shutil.copytree(op.join("build", "locale"), op.join(destpath, "locale"))
+    except Exception as e:
+        print(f"Warning: exception: {e}")
     compileall.compile_dir(destpath)
 
 

--- a/package.py
+++ b/package.py
@@ -43,14 +43,17 @@ def copy_files_to_package(destpath, packages, with_so):
     shutil.copy("run.py", op.join(destpath, "run.py"))
     extra_ignores = ["*.so"] if not with_so else None
     copy_packages(packages, destpath, extra_ignores=extra_ignores)
-    try:
-        shutil.copytree(op.join("build", "help"), op.join(destpath, "help"))
-    except Exception as e:
-        print(f"Warning: exception: {e}")
-    try:
-        shutil.copytree(op.join("build", "locale"), op.join(destpath, "locale"))
-    except Exception as e:
-        print(f"Warning: exception: {e}")
+    # include locale files if they are built otherwise exit as it will break
+    # the localization
+    if not op.exists("build/locale"):
+        print("Locale files not built, exiting...")
+        return
+    # include help files if they are built otherwise exit as they should be included?
+    if not op.exists("build/help"):
+        print("Help files not built, exiting...")
+        return
+    shutil.copytree(op.join("build", "help"), op.join(destpath, "help"))
+    shutil.copytree(op.join("build", "locale"), op.join(destpath, "locale"))
     compileall.compile_dir(destpath)
 
 

--- a/package.py
+++ b/package.py
@@ -46,11 +46,11 @@ def copy_files_to_package(destpath, packages, with_so):
     # include locale files if they are built otherwise exit as it will break
     # the localization
     if not op.exists("build/locale"):
-        print("Locale files not built, exiting...")
+        print("Locale files are missing. Have you run \"build.py --loc\"? Exiting...")
         return
     # include help files if they are built otherwise exit as they should be included?
     if not op.exists("build/help"):
-        print("Help files not built, exiting...")
+        print("Help files are missing. Have you run \"build.py --help\"? Exiting...")
         return
     shutil.copytree(op.join("build", "help"), op.join(destpath, "help"))
     shutil.copytree(op.join("build", "locale"), op.join(destpath, "locale"))
@@ -161,11 +161,11 @@ def package_windows():
     # include locale files if they are built otherwise exit as it will break
     # the localization
     if not op.exists("build/locale"):
-        print("Locale files not built, exiting...")
+        print("Locale files are missing. Have you run \"build.py --loc\"? Exiting...")
         return
     # include help files if they are built otherwise exit as they should be included?
     if not op.exists("build/help"):
-        print("Help files not built, exiting...")
+        print("Help files are missing. Have you run \"build.py --help\"? Exiting...")
         return
     # create version information file from template
     try:


### PR DESCRIPTION
* While packaging, the "build/help" and "build/locale" directories are not found.
* Work around the issue with try/except statements.
* This probably affects packaging for other distributions as well.