### PR TITLE
Workaround for #630

### DIFF
--- a/qt/pe/photo.py
+++ b/qt/pe/photo.py
@@ -30,9 +30,14 @@ class File(PhotoBase):
         image = QImage(str(self.path))
         image = image.convertToFormat(QImage.Format_RGB888)
         if type(orientation) == str:
-            logging.warning("Orientation for file '%s' was a str '%s', not an int!",
+            logging.warning("Orientation for file '%s' was a str '%s', not an int.",
                             str(self.path), orientation)
-            return getblocks(image, block_count_per_side)
+            try:
+                orientation = int(orientation)
+            except Exception as e:
+                logging.exception("Skipping transformation because could not \
+convert str to int. %s", e)
+                return getblocks(image, block_count_per_side)
         # MYSTERY TO SOLVE: For reasons I cannot explain, orientations 5 and 7 don't work for
         # duplicate scanning. The transforms seems to work fine (if I try to save the image after
         # the transform, we see that the image has been correctly flipped and rotated), but the

--- a/qt/pe/photo.py
+++ b/qt/pe/photo.py
@@ -29,6 +29,10 @@ class File(PhotoBase):
     def _plat_get_blocks(self, block_count_per_side, orientation):
         image = QImage(str(self.path))
         image = image.convertToFormat(QImage.Format_RGB888)
+        if type(orientation) == str:
+            logging.warning("Orientation for file '%s' was a str '%s', not an int!",
+                            str(self.path), orientation)
+            return getblocks(image, block_count_per_side)
         # MYSTERY TO SOLVE: For reasons I cannot explain, orientations 5 and 7 don't work for
         # duplicate scanning. The transforms seems to work fine (if I try to save the image after
         # the transform, we see that the image has been correctly flipped and rotated), but the


### PR DESCRIPTION
This is a proposed workaround for #630.
* In some cases, the function dump_IFD() in core/pe/exif.py assigns a string instead of an int as "values".
* This value is then used as _cached_orientation in core/pe/photo.py in _get_orientation().
* The method _plat_get_blocks() in qt/pe/photo.py was only expecting an integer for the orientation argument, so we work around the issue for now by ignoring the value if it's a string.