### PR TITLE
Added pyqt5 to requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ endif
 	@${PYTHON} -c 'import PyQt5' >/dev/null 2>&1 || \
 		{ echo "PyQt 5.4+ required. Install it and try again. Aborting"; exit 1; }
 
-env : | reqs
+env : requirements.txt | reqs
 ifndef NO_VENV
 	@echo "Creating our virtualenv"
 	${PYTHON} -m venv env

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ This folder contains the source for dupeGuru. Its documentation is in `help`, bu
 ### Windows
 For windows instructions see the [Windows Instructions](Windows.md).
 
+### Ubuntu
+You'll need venv and Python dev tools to make the project. So ensure you've tried this before starting:
+
+```
+$ apt install python3-venv
+$ apt install python3-dev
+```
+
 ### Prerequisites
 
 * [Python 3.5+][python]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pyqt5>=5.15.1
 Send2Trash>=1.3.0
 sphinx>=1.2.2
 polib>=1.0.4


### PR DESCRIPTION
Starting afresh on Mint 20 I forked/cloned and ran `make`. All good. Then make`run` failed on a missing module PyQt5. But I have that installed, no problems. So what was up? Turns out the Makefile uses a venv, which is nice, but for whatever reason elects not to include pyqt5 in requirements that it installs in the venv. Perhaps there's a good reason for that I'm missing, and this PR invalid. Feedback welcome.

But for now I added it with latest version and well, it worked, and pyqt5 is in the venv now. 