### PR TITLE
Make icon path relative

### DIFF
--- a/pkg/arch/dupeguru.json
+++ b/pkg/arch/dupeguru.json
@@ -3,5 +3,5 @@
 	"longname": "dupeGuru",
 	"execname": "dupeguru",
 	"arch": "any",
-	"iconpath": "/usr/share/dupeguru/dgse_logo_128.png"
+	"iconpath": "dupeguru"
 }

--- a/pkg/debian/Makefile
+++ b/pkg/debian/Makefile
@@ -8,4 +8,5 @@ all:
 	chmod +x src/run.py
 	cp -R src/ "$(CURDIR)/debian/{pkgname}/usr/share/{execname}"
 	cp "$(CURDIR)/debian/{execname}.desktop" "$(CURDIR)/debian/{pkgname}/usr/share/applications"
+	ln -s "/usr/share/{execname}/dgse_logo_128.png" "$(CURDIR)/debian/{pkgname}/usr/pixmaps/{execname}.png"
 	ln -s "/usr/share/{execname}/run.py" "$(CURDIR)/debian/{pkgname}/usr/bin/{execname}"

--- a/pkg/debian/dupeguru.json
+++ b/pkg/debian/dupeguru.json
@@ -3,5 +3,5 @@
 	"longname": "dupeGuru",
 	"execname": "dupeguru",
 	"arch": "any",
-	"iconpath": "/usr/share/dupeguru/dgse_logo_128.png"
+	"iconpath": "dupeguru"
 }


### PR DESCRIPTION
* Removes the hardcoded path to the icon in the .desktop file
* Allows themes to override the default application icon (icons are searched for in theme paths first)
* Debian: create symbolic link in /usr/share/pixmaps that points to the icon file
* Arch: the same thing is done by PKGBUILD maintainers downstream