### PR TITLE
Fix Debian packaging issues

### DIFF
--- a/hscommon/build.py
+++ b/hscommon/build.py
@@ -295,7 +295,7 @@ def build_debian_changelog(
         return [s.strip() for s in result if s.strip()]
 
     ENTRY_MODEL = (
-        "{pkg} ({version}-1) {distribution}; urgency=low\n\n{changes}\n "
+        "{pkg} ({version}) {distribution}; urgency=low\n\n{changes}\n "
         "-- Virgil Dupras <hsoft@hardcoded.net>  {date}\n\n"
     )
     CHANGE_MODEL = "  * {description}\n"

--- a/pkg/debian/Makefile
+++ b/pkg/debian/Makefile
@@ -8,6 +8,6 @@ all:
 	chmod +x src/run.py
 	cp -R src/ "$(CURDIR)/debian/{pkgname}/usr/share/{execname}"
 	cp "$(CURDIR)/debian/{execname}.desktop" "$(CURDIR)/debian/{pkgname}/usr/share/applications"
-	mkdir -p "$(CURDIR)/debian/{pkgname}/usr/pixmaps"
+	mkdir -p "$(CURDIR)/debian/{pkgname}/usr/share/pixmaps"
 	ln -s "/usr/share/{execname}/dgse_logo_128.png" "$(CURDIR)/debian/{pkgname}/usr/share/pixmaps/{execname}.png"
 	ln -s "/usr/share/{execname}/run.py" "$(CURDIR)/debian/{pkgname}/usr/bin/{execname}"

--- a/pkg/debian/Makefile
+++ b/pkg/debian/Makefile
@@ -9,5 +9,5 @@ all:
 	cp -R src/ "$(CURDIR)/debian/{pkgname}/usr/share/{execname}"
 	cp "$(CURDIR)/debian/{execname}.desktop" "$(CURDIR)/debian/{pkgname}/usr/share/applications"
 	mkdir -p "$(CURDIR)/debian/{pkgname}/usr/pixmaps"
-	ln -s "/usr/share/{execname}/dgse_logo_128.png" "$(CURDIR)/debian/{pkgname}/usr/pixmaps/{execname}.png"
+	ln -s "/usr/share/{execname}/dgse_logo_128.png" "$(CURDIR)/debian/{pkgname}/usr/share/pixmaps/{execname}.png"
 	ln -s "/usr/share/{execname}/run.py" "$(CURDIR)/debian/{pkgname}/usr/bin/{execname}"

--- a/pkg/debian/Makefile
+++ b/pkg/debian/Makefile
@@ -8,5 +8,6 @@ all:
 	chmod +x src/run.py
 	cp -R src/ "$(CURDIR)/debian/{pkgname}/usr/share/{execname}"
 	cp "$(CURDIR)/debian/{execname}.desktop" "$(CURDIR)/debian/{pkgname}/usr/share/applications"
+	mkdir -p "$(CURDIR)/debian/{pkgname}/usr/pixmaps"
 	ln -s "/usr/share/{execname}/dgse_logo_128.png" "$(CURDIR)/debian/{pkgname}/usr/pixmaps/{execname}.png"
 	ln -s "/usr/share/{execname}/run.py" "$(CURDIR)/debian/{pkgname}/usr/bin/{execname}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Send2Trash>=1.3.0
 sphinx>=1.2.2
 polib>=1.0.4
-hsaudiotag3k>=1.1.3
+hsaudiotag3k>=1.1.3*
 distro>=1.5.0
 PyQt5 >=5.4,<6.0; sys_platform == 'win32'
 pywin32>=200; sys_platform == 'win32'


### PR DESCRIPTION
* The hscommon build ENTRY_MODEL template seems to be causing an error in Debian while packaging: "error: can't build with source format '3.0 (native)': native package version may not have a revision". 
Removing the dash revision number seems to work around the issue.
* The directory holding the symbolic link to the pixmap has to be created first