### PR TITLE
Fix stripping (japanese) unicode characters

### DIFF
--- a/core/engine.py
+++ b/core/engine.py
@@ -26,8 +26,19 @@ def getwords(s):
     # We decompose the string so that ascii letters with accents can be part of the word.
     s = normalize("NFD", s)
     s = multi_replace(s, "-_&+():;\\[]{}.,<>/?~!@#$*", " ").lower()
+    # logging.debug(f"DEBUG chars for: {s}\n"
+    #               f"{[c for c in s if ord(c) != 32]}\n"
+    #               f"{[ord(c) for c in s if ord(c) != 32]}")
+    # HACK We shouldn't ignore non-ascii characters altogether. Any Unicode char
+    # above common european characters that cannot be "sanitized" (ie. stripped
+    # of their accents, etc.) are preserved as is. The arbitrary limit is
+    # obtained from this one: ord("\u037e") GREEK QUESTION MARK
     s = "".join(
-        c for c in s if c in string.ascii_letters + string.digits + string.whitespace
+        c for c in s
+        if (ord(c) < 894
+            and c in string.ascii_letters + string.digits + string.whitespace
+            )
+        or ord(c) > 894
     )
     return [_f for _f in s.split(" ") if _f]  # remove empty elements
 

--- a/core/engine.py
+++ b/core/engine.py
@@ -35,7 +35,7 @@ def getwords(s):
     # obtained from this one: ord("\u037e") GREEK QUESTION MARK
     s = "".join(
         c for c in s
-        if (ord(c) < 894
+        if (ord(c) <= 894
             and c in string.ascii_letters + string.digits + string.whitespace
             )
         or ord(c) > 894

--- a/core/tests/engine_test.py
+++ b/core/tests/engine_test.py
@@ -69,6 +69,10 @@ class TestCasegetwords:
         eq_(["a", "b", "c", "d"], getwords("a b c d"))
         eq_(["a", "b", "c", "d"], getwords(" a  b  c d "))
 
+    def test_unicode(self):
+        eq_(["e", "c", "0", "a", "o", "u", "e", "u"], getwords("é ç 0 à ö û è ¤ ù"))
+        eq_(["02", "君のこころは輝いてるかい？", "国木田花丸", "solo", "ver"], getwords("02 君のこころは輝いてるかい？ 国木田花丸 Solo Ver"))
+
     def test_splitter_chars(self):
         eq_(
             [chr(i) for i in range(ord("a"), ord("z") + 1)],
@@ -85,7 +89,7 @@ class TestCasegetwords:
         eq_(["foo", "bar"], getwords("FOO BAR"))
 
     def test_decompose_unicode(self):
-        eq_(getwords("foo\xe9bar"), ["fooebar"])
+        eq_(["fooebar"], getwords("foo\xe9bar"))
 
 
 class TestCasegetfields:


### PR DESCRIPTION
This "stripping of accents" doesn't look right to me. It would be just as good to keep words accentuated and compare them that way. 

For example, "ébé.mp3" and "ebe.mp3" appear in the results as "100%" match, which obviously isn't right at all.

This algorithm might be a bit dated now, and perhaps there is some sort of technical debt left from the python2 to python3 migration (since Unicode strings are now the default). 

Maybe it could be safe to remove this altogether, I'm not sure. For now I've left it as is, but it might be worth considering.