### PR TITLE
Missing renamed regex

### DIFF
--- a/core/directories.py
+++ b/core/directories.py
@@ -108,24 +108,9 @@ class Directories:
                         found_files = []
                         # print(f"len of files: {len(files)} {files}")
                         for f in files:
-                            matched = False
-                            for expr in self._exclude_list.compiled_files:
-                                if expr.fullmatch(f):
-                                    logging.debug(f"{expr} matched {f}.")
-                                    matched = True
-                                    break
-                            if not matched:
-                                logging.debug(f"path {root + os.sep + f}")
-                                for expr in self._exclude_list.compiled_paths:
-                                    if expr.fullmatch(root + os.sep + f):
-                                        print(f"{expr} matched {root}{os.sep}{f}.")
-                                        matched = True
-                                        break
-                            if not matched:
-                                logging.debug(f"Not filtering: {f}.")
-                                found_files.append(fs.get_file(rootPath + f, fileclasses=fileclasses))
-                            else:
-                                logging.debug(f"Filtering: {f}")
+                            if not self._exclude_list.is_excluded(root, f):
+                                found_files.append(fs.get_file(rootPath + f,
+                                                               fileclasses=fileclasses))
                     found_files = [f for f in found_files if f is not None]
                     # In some cases, directories can be considered as files by dupeGuru, which is
                     # why we have this line below. In fact, there only one case: Bundle files under

--- a/core/directories.py
+++ b/core/directories.py
@@ -108,18 +108,24 @@ class Directories:
                         found_files = []
                         # print(f"len of files: {len(files)} {files}")
                         for f in files:
-                            found = False
+                            matched = False
                             for expr in self._exclude_list.compiled_files:
-                                if expr.match(f):
-                                    found = True
+                                if expr.fullmatch(f):
+                                    logging.debug(f"{expr} matched {f}.")
+                                    matched = True
                                     break
-                            if not found:
+                            if not matched:
+                                logging.debug(f"path {root + os.sep + f}")
                                 for expr in self._exclude_list.compiled_paths:
-                                    if expr.match(root + os.sep + f):
-                                        found = True
+                                    if expr.fullmatch(root + os.sep + f):
+                                        print(f"{expr} matched {root}{os.sep}{f}.")
+                                        matched = True
                                         break
-                            if not found:
+                            if not matched:
+                                logging.debug(f"Not filtering: {f}.")
                                 found_files.append(fs.get_file(rootPath + f, fileclasses=fileclasses))
+                            else:
+                                logging.debug(f"Filtering: {f}")
                     found_files = [f for f in found_files if f is not None]
                     # In some cases, directories can be considered as files by dupeGuru, which is
                     # why we have this line below. In fact, there only one case: Bundle files under

--- a/core/gui/exclude_list_dialog.py
+++ b/core/gui/exclude_list_dialog.py
@@ -56,7 +56,7 @@ class ExcludeListDialogCore:
         matched = False
         for row in self.exclude_list_table.rows:
             compiled_regex = self.exclude_list.get_compiled(row.regex)
-            if compiled_regex and compiled_regex.match(test_string):
+            if compiled_regex and compiled_regex.fullmatch(test_string):
                 matched = True
                 row.highlight = True
             else:

--- a/core/gui/exclude_list_dialog.py
+++ b/core/gui/exclude_list_dialog.py
@@ -7,6 +7,8 @@
 
 # from hscommon.trans import tr
 from .exclude_list_table import ExcludeListTable
+from core.exclude import has_sep
+from os import sep
 import logging
 
 
@@ -30,9 +32,10 @@ class ExcludeListDialogCore:
         self.refresh()
 
     def rename_selected(self, newregex):
-        """Renames the selected regex to ``newregex``.
-        If there's more than one selected row, the first one is used.
+        """Rename the selected regex to ``newregex``.
+        If there is more than one selected row, the first one is used.
         :param str newregex: The regex to rename the row's regex to.
+        :return bool: true if success, false if error.
         """
         try:
             r = self.exclude_list_table.selected_rows[0]
@@ -52,15 +55,35 @@ class ExcludeListDialogCore:
         self.exclude_list_table.add(regex)
 
     def test_string(self, test_string):
-        """Sets property on row to highlight if its regex matches test_string supplied."""
+        """Set the highlight property on each row when its regex matches the
+        test_string supplied. Return True if any row matched."""
         matched = False
         for row in self.exclude_list_table.rows:
             compiled_regex = self.exclude_list.get_compiled(row.regex)
-            if compiled_regex and compiled_regex.fullmatch(test_string):
-                matched = True
+
+            if self.is_match(test_string, compiled_regex):
                 row.highlight = True
+                matched = True
             else:
                 row.highlight = False
+        return matched
+
+    def is_match(self, test_string, compiled_regex):
+        # This method is like an inverted version of ExcludeList.is_excluded()
+        if not compiled_regex:
+            return False
+        matched = False
+
+        # Test only the filename portion of the path
+        if not has_sep(compiled_regex.pattern) and sep in test_string:
+            filename = test_string.rsplit(sep, 1)[1]
+            if compiled_regex.fullmatch(filename):
+                matched = True
+            return matched
+
+        # Test the entire path + filename
+        if compiled_regex.fullmatch(test_string):
+            matched = True
         return matched
 
     def reset_rows_highlight(self):

--- a/core/gui/exclude_list_table.py
+++ b/core/gui/exclude_list_table.py
@@ -36,7 +36,7 @@ class ExcludeListTable(GUITable, DupeGuruGUIObject):
         return ExcludeListRow(self, self.dialog.exclude_list.is_marked(regex), regex), 0
 
     def _do_delete(self):
-        self.dalog.exclude_list.remove(self.selected_row.regex)
+        self.dialog.exclude_list.remove(self.selected_row.regex)
 
     # --- Override
     def add(self, regex):

--- a/core/tests/directories_test.py
+++ b/core/tests/directories_test.py
@@ -473,6 +473,24 @@ files: {self.d._exclude_list.compiled_files} all: {self.d._exclude_list.compiled
         assert "file_ending_with_subdir" not in files
         assert "file_which_shouldnt_match" in files
 
+        # This should match the directory only
+        regex6 = r".*/subdir.*"
+        if ISWINDOWS:
+            regex6 = r".*\\.*subdir.*"
+        self.d._exclude_list.rename(regex5, regex6)
+        self.d._exclude_list.remove(regex1)
+        assert regex1 not in self.d._exclude_list
+        assert regex5 not in self.d._exclude_list
+        assert self.d._exclude_list.error(regex6) is None
+        # This still should not be affected
+        eq_(self.d.get_state(p1["$Recycle.Bin"]["subdir"]), DirectoryState.Normal)
+        files = self.get_files_and_expect_num_result(5)
+        # These files are under the "/subdir" directory
+        assert "somesubdirfile.png" not in files
+        assert "unwanted_subdirfile.gif" not in files
+        # This file under "subdar" directory should not be filtered out
+        assert "file_ending_with_subdir" in files
+
     def test_japanese_unicode(self, tmpdir):
         p1 = Path(str(tmpdir))
         p1["$Recycle.Bin"].mkdir()

--- a/core/tests/exclude_test.py
+++ b/core/tests/exclude_test.py
@@ -188,6 +188,28 @@ class TestCaseListEmpty:
         self.exclude_list.rename(regex_renamed_compilable, regex_compilable)
         eq_(self.exclude_list.is_marked(regex_compilable), True)
 
+    def test_rename_regex_file_to_path(self):
+        regex = r".*/one.*"
+        if ISWINDOWS:
+            regex = r".*\\one.*"
+        regex2 = r".*one.*"
+        self.exclude_list.add(regex)
+        self.exclude_list.mark(regex)
+        compiled_re = [x.pattern for x in self.exclude_list._excluded_compiled]
+        files_re = [x.pattern for x in self.exclude_list.compiled_files]
+        paths_re = [x.pattern for x in self.exclude_list.compiled_paths]
+        assert regex in compiled_re
+        assert regex not in files_re
+        assert regex in paths_re
+        self.exclude_list.rename(regex, regex2)
+        compiled_re = [x.pattern for x in self.exclude_list._excluded_compiled]
+        files_re = [x.pattern for x in self.exclude_list.compiled_files]
+        paths_re = [x.pattern for x in self.exclude_list.compiled_paths]
+        assert regex not in compiled_re
+        assert regex2 in compiled_re
+        assert regex2 in files_re
+        assert regex2 not in paths_re
+
     def test_restore_default(self):
         """Only unmark previously added regexes and mark the pre-defined ones"""
         regex = r"one"
@@ -213,12 +235,146 @@ class TestCaseListEmpty:
         eq_(len(default_regexes), len(self.exclude_list.compiled))
 
 
+class TestCaseListEmptyUnion(TestCaseListEmpty):
+    """Same but with union regex"""
+    def setup_method(self, method):
+        self.app = DupeGuru()
+        self.app.exclude_list = ExcludeList(union_regex=True)
+        self.exclude_list = self.app.exclude_list
+
+    def test_add_mark_and_remove_regex(self):
+        regex1 = r"one"
+        regex2 = r"two"
+        self.exclude_list.add(regex1)
+        assert(regex1 in self.exclude_list)
+        self.exclude_list.add(regex2)
+        self.exclude_list.mark(regex1)
+        self.exclude_list.mark(regex2)
+        eq_(len(self.exclude_list), 2)
+        eq_(len(self.exclude_list.compiled), 1)
+        compiled_files = [x for x in self.exclude_list.compiled_files]
+        eq_(len(compiled_files), 1)  # Two patterns joined together into one
+        assert "|" in compiled_files[0].pattern
+        self.exclude_list.remove(regex2)
+        assert(regex2 not in self.exclude_list)
+        eq_(len(self.exclude_list), 1)
+
+    def test_rename_regex_file_to_path(self):
+        regex = r".*/one.*"
+        if ISWINDOWS:
+            regex = r".*\\one.*"
+        regex2 = r".*one.*"
+        self.exclude_list.add(regex)
+        self.exclude_list.mark(regex)
+        eq_(len([x for x in self.exclude_list]), 1)
+        compiled_re = [x.pattern for x in self.exclude_list.compiled]
+        files_re = [x.pattern for x in self.exclude_list.compiled_files]
+        paths_re = [x.pattern for x in self.exclude_list.compiled_paths]
+        assert regex in compiled_re
+        assert regex not in files_re
+        assert regex in paths_re
+        self.exclude_list.rename(regex, regex2)
+        eq_(len([x for x in self.exclude_list]), 1)
+        compiled_re = [x.pattern for x in self.exclude_list.compiled]
+        files_re = [x.pattern for x in self.exclude_list.compiled_files]
+        paths_re = [x.pattern for x in self.exclude_list.compiled_paths]
+        assert regex not in compiled_re
+        assert regex2 in compiled_re
+        assert regex2 in files_re
+        assert regex2 not in paths_re
+
+    def test_restore_default(self):
+        """Only unmark previously added regexes and mark the pre-defined ones"""
+        regex = r"one"
+        self.exclude_list.add(regex)
+        self.exclude_list.mark(regex)
+        self.exclude_list.restore_defaults()
+        eq_(len(default_regexes), self.exclude_list.marked_count)
+        # added regex shouldn't be marked
+        eq_(self.exclude_list.is_marked(regex), False)
+        # added regex shouldn't be in compiled list either
+        compiled = [x for x in self.exclude_list.compiled]
+        assert regex not in compiled
+        # Need to escape both to get the same strings after compilation
+        compiled_escaped = set([x.encode('unicode-escape').decode() for x in compiled[0].pattern.split("|")])
+        default_escaped = set([x.encode('unicode-escape').decode() for x in default_regexes])
+        assert compiled_escaped == default_escaped
+        eq_(len(default_regexes), len(compiled[0].pattern.split("|")))
+
+
 class TestCaseDictEmpty(TestCaseListEmpty):
     """Same, but with dictionary implementation"""
     def setup_method(self, method):
         self.app = DupeGuru()
         self.app.exclude_list = ExcludeDict(union_regex=False)
         self.exclude_list = self.app.exclude_list
+
+
+class TestCaseDictEmptyUnion(TestCaseDictEmpty):
+    """Same, but with union regex"""
+    def setup_method(self, method):
+        self.app = DupeGuru()
+        self.app.exclude_list = ExcludeDict(union_regex=True)
+        self.exclude_list = self.app.exclude_list
+
+    def test_add_mark_and_remove_regex(self):
+        regex1 = r"one"
+        regex2 = r"two"
+        self.exclude_list.add(regex1)
+        assert(regex1 in self.exclude_list)
+        self.exclude_list.add(regex2)
+        self.exclude_list.mark(regex1)
+        self.exclude_list.mark(regex2)
+        eq_(len(self.exclude_list), 2)
+        eq_(len(self.exclude_list.compiled), 1)
+        compiled_files = [x for x in self.exclude_list.compiled_files]
+        # two patterns joined into one
+        eq_(len(compiled_files), 1)
+        self.exclude_list.remove(regex2)
+        assert(regex2 not in self.exclude_list)
+        eq_(len(self.exclude_list), 1)
+
+    def test_rename_regex_file_to_path(self):
+        regex = r".*/one.*"
+        if ISWINDOWS:
+            regex = r".*\\one.*"
+        regex2 = r".*one.*"
+        self.exclude_list.add(regex)
+        self.exclude_list.mark(regex)
+        marked_re = [x for marked, x in self.exclude_list if marked]
+        eq_(len(marked_re), 1)
+        compiled_re = [x.pattern for x in self.exclude_list.compiled]
+        files_re = [x.pattern for x in self.exclude_list.compiled_files]
+        paths_re = [x.pattern for x in self.exclude_list.compiled_paths]
+        assert regex in compiled_re
+        assert regex not in files_re
+        assert regex in paths_re
+        self.exclude_list.rename(regex, regex2)
+        compiled_re = [x.pattern for x in self.exclude_list.compiled]
+        files_re = [x.pattern for x in self.exclude_list.compiled_files]
+        paths_re = [x.pattern for x in self.exclude_list.compiled_paths]
+        assert regex not in compiled_re
+        assert regex2 in compiled_re
+        assert regex2 in files_re
+        assert regex2 not in paths_re
+
+    def test_restore_default(self):
+        """Only unmark previously added regexes and mark the pre-defined ones"""
+        regex = r"one"
+        self.exclude_list.add(regex)
+        self.exclude_list.mark(regex)
+        self.exclude_list.restore_defaults()
+        eq_(len(default_regexes), self.exclude_list.marked_count)
+        # added regex shouldn't be marked
+        eq_(self.exclude_list.is_marked(regex), False)
+        # added regex shouldn't be in compiled list either
+        compiled = [x for x in self.exclude_list.compiled]
+        assert regex not in compiled
+        # Need to escape both to get the same strings after compilation
+        compiled_escaped = set([x.encode('unicode-escape').decode() for x in compiled[0].pattern.split("|")])
+        default_escaped = set([x.encode('unicode-escape').decode() for x in default_regexes])
+        assert compiled_escaped == default_escaped
+        eq_(len(default_regexes), len(compiled[0].pattern.split("|")))
 
 
 def split_union(pattern_object):

--- a/qt/exclude_list_dialog.py
+++ b/qt/exclude_list_dialog.py
@@ -116,30 +116,32 @@ class ExcludeListDialog(QDialog):
         if not input_text:
             self.reset_input_style()
             return
-        # if at least one row matched, we know whether table is highlighted or not
+        # If at least one row matched, we know whether table is highlighted or not
         self._row_matched = self.model.test_string(input_text)
         self.table.refresh()
 
+        # Test the string currently in the input text box as well
         input_regex = self.inputLine.text()
         if not input_regex:
             self.reset_input_style()
             return
+        compiled = None
         try:
             compiled = re.compile(input_regex)
         except re.error:
             self.reset_input_style()
             return
-        if compiled.fullmatch(input_text):
-            self._input_styled = True
+        if self.model.is_match(input_text, compiled):
             self.inputLine.setStyleSheet("background-color: rgb(10, 200, 10);")
+            self._input_styled = True
         else:
             self.reset_input_style()
 
     def reset_input_style(self):
         """Reset regex input line background"""
         if self._input_styled:
-            self._input_styled = False
             self.inputLine.setStyleSheet(self.styleSheet())
+            self._input_styled = False
 
     def reset_table_style(self):
         if self._row_matched:

--- a/qt/exclude_list_dialog.py
+++ b/qt/exclude_list_dialog.py
@@ -129,8 +129,7 @@ class ExcludeListDialog(QDialog):
         except re.error:
             self.reset_input_style()
             return
-        match = compiled.match(input_text)
-        if match:
+        if compiled.fullmatch(input_text):
             self._input_styled = True
             self.inputLine.setStyleSheet("background-color: rgb(10, 200, 10);")
         else:


### PR DESCRIPTION
* Fix a regex that was missing after a regex rename.
* Fix partial regex match yielding false positive (especially in the exclusion filter dialog window, which showed the test string being matched when in fact it should not match). 
* Fix regex not being cached into the path filters when a directory separator was found in its pattern.