### PR TITLE
Add webp image format support

### DIFF
--- a/core/pe/photo.py
+++ b/core/pe/photo.py
@@ -29,7 +29,7 @@ class Photo(fs.File):
     __slots__ = fs.File.__slots__ + tuple(INITIAL_INFO.keys())
 
     # These extensions are supported on all platforms
-    HANDLED_EXTS = {"png", "jpg", "jpeg", "gif", "bmp", "tiff", "tif"}
+    HANDLED_EXTS = {"png", "jpg", "jpeg", "gif", "bmp", "tiff", "tif", "webp"}
 
     def _plat_get_dimensions(self):
         raise NotImplementedError()


### PR DESCRIPTION
Following https://github.com/arsenetar/dupeguru/issues/934 discussion this commit adds webp support.
Basic testing showed it is working.

Ubuntu users will probably need to install webp-pixbuf-load to be able to display webp images in file managers and inside dupeguru ("Details" button in results dialog).
I have uploaded webp-pixbuf-load package to PPA.
