### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ PyQt5 >=5.15.0,<6.0; sys_platform != 'linux'
 pywin32>=304; sys_platform == 'win32'
 semantic-version>=2.0.0,<3.0.0
 Send2Trash>=1.8.2,<2.0.0
-sphinx>=5.3.0,<7.0.0
+sphinx>=5.3.0,<8.0.0
 xxhash>=3.0.0,<4.0.0


### PR DESCRIPTION
sphinx 7.0.0 was released on April 29th.

Arch Linux has sphinx 7.0.1 in the official repositories, and I would like to be able to use that with dupeguru.