### PR TITLE
Update python versions in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,py310
+envlist = py37,py38,py39,py310,py311
 skipsdist = True
 skip_missing_interpreters = True
 


### PR DESCRIPTION
Python 3.6 support was already dropped in commit b9dfeac2 ("Drop Python 3.6 Support"). Don't attempt to run tests with it if it is installed.

Python 3.11 is currently supported, so add it to the list.