### PR TITLE
Use isolation_level=None mode for GNU Hurd

### DIFF
--- a/core/fs.py
+++ b/core/fs.py
@@ -16,6 +16,7 @@ import os
 from math import floor
 import logging
 import sqlite3
+from sys import platform
 from threading import Lock
 from typing import Any, AnyStr, Union, Callable
 
@@ -118,7 +119,10 @@ class FilesDB:
         self.lock = None
 
     def connect(self, path: Union[AnyStr, os.PathLike]) -> None:
-        self.conn = sqlite3.connect(path, check_same_thread=False)
+        if platform.startswith("gnu0"):
+            self.conn = sqlite3.connect(path, check_same_thread=False, isolation_level=None)
+        else:
+            self.conn = sqlite3.connect(path, check_same_thread=False)
         self.lock = Lock()
         self._check_upgrade()
 


### PR DESCRIPTION
Connection to SQLite sometimes fails on GNU Hurd because of the different locking mechanism used there compared to other *NIXes, leading to failures in test suite, see [Debian buildd log](https://buildd.debian.org/status/fetch.php?pkg=dupeguru&arch=hurd-i386&ver=4.3.1-4&stamp=1707486215&raw=0), in particular where test suite fails with _sqlite3.OperationalError: database is locked_