### PR TITLE
Fix command injection in Custom Command

### DIFF
--- a/core/app.py
+++ b/core/app.py
@@ -9,8 +9,8 @@ import datetime
 import os
 import os.path as op
 import logging
+import shlex
 import subprocess
-import re
 import shutil
 from pathlib import Path
 
@@ -544,24 +544,22 @@ class DupeGuru(Broadcaster):
         dupes = self.selected_dupes
         refs = [self.results.get_group_of_duplicate(dupe).ref for dupe in dupes]
         for dupe, ref in zip(dupes, refs):
-            dupe_cmd = cmd.replace("%d", str(dupe.path))
-            dupe_cmd = dupe_cmd.replace("%r", str(ref.path))
-            match = re.match(r'"([^"]+)"(.*)', dupe_cmd)
-            if match is not None:
-                # This code here is because subprocess. Popen doesn't seem to accept, under Windows,
-                # executable paths with spaces in it, *even* when they're enclosed in "". So this is
-                # a workaround to make the damn thing work.
-                exepath, args = match.groups()
-                path, exename = op.split(exepath)
-                p = subprocess.Popen(
-                    exename + args, shell=True, cwd=path, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-                )
+            # Tokenize the command template safely before substituting paths
+            try:
+                cmd_parts = shlex.split(cmd)
+            except ValueError as e:
+                logging.error("Invalid custom command syntax: %s", e)
+                self.view.show_message(tr("Invalid custom command syntax: {}").format(str(e)))
+                return
+            # Replace placeholders in each token individually to prevent injection
+            cmd_parts = [part.replace("%d", str(dupe.path)).replace("%r", str(ref.path)) for part in cmd_parts]
+            try:
+                p = subprocess.Popen(cmd_parts, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
                 output = p.stdout.read()
-                logging.info("Custom command %s %s: %s", exename, args, output)
-            else:
-                p = subprocess.Popen(dupe_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-                output = p.stdout.read()
-                logging.info("Custom command %s: %s", dupe_cmd, output)
+                logging.info("Custom command %s: %s", cmd_parts, output)
+            except OSError as e:
+                logging.error("Failed to execute custom command %s: %s", cmd_parts, e)
+                self.view.show_message(tr("Failed to execute custom command: {}").format(str(e)))
 
     def load(self):
         """Load directory selection and ignore list from files in appdata.


### PR DESCRIPTION
## Context

During a security audit of dupeGuru, we identified a **command injection vulnerability** in the Custom Command feature.

## Vulnerability

The code at `core/app.py` in `invoke_custom_command()` constructs a shell command by performing string substitution on the user's custom command template, replacing `%d` and `%r` with file paths, then passes the resulting string to `subprocess.Popen()` with `shell=True`:

```python
cmd = cmd.replace("%d", str(dupe.path))
cmd = cmd.replace("%r", str(ref.path))
p = subprocess.Popen(cmd, shell=True, ...)
```

Because `shell=True` passes the entire string to the system shell for interpretation, any shell metacharacters in file paths are evaluated. A file named `$(rm -rf ~).txt` would cause arbitrary command execution when the user invokes a custom command on it.

The existing Windows workaround (wrapping paths in quotes) is insufficient — it doesn't handle all injection vectors and doesn't protect Unix/macOS at all.

## Attack scenario

1. An attacker places a file with a crafted name in a directory the user scans
2. dupeGuru detects it as a duplicate
3. The user invokes their custom command (e.g., a diff tool) on this file
4. The shell executes the embedded command with the user's privileges

## Fix

- Use `shlex.split(cmd)` to tokenize the command template into a list of arguments
- Perform `%d`/`%r` substitution on each token individually (so paths stay within their token boundary)
- Call `subprocess.Popen(cmd_parts, shell=False)` — arguments are passed directly to the OS without shell interpretation
- Remove the Windows quoted-path workaround (no longer needed with `shell=False`)
- Add proper error handling for malformed command templates and execution failures

## Test plan

- [x] `pytest core/tests/app_test.py` — 38 tests pass
- [ ] Manual test: create a file with shell metacharacters in the name, invoke custom command, verify no shell expansion occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)