### PR TITLE
Improve privacy: log rotation, temp cleanup, sensitive file exclusions

### DIFF
--- a/core/app.py
+++ b/core/app.py
@@ -137,6 +137,7 @@ class DupeGuru(Broadcaster):
             os.makedirs(self.appdata)
         self.app_mode = AppMode.STANDARD
         self.discarded_file_count = 0
+        self._last_export_temp_dir = None
         self.exclude_list = ExcludeList()
         hash_cache_file = op.join(self.appdata, "hash_cache.db")
         fs.filesdb.connect(hash_cache_file)
@@ -497,8 +498,11 @@ class DupeGuru(Broadcaster):
         determine how the data is presented in the export. In other words, the exported table in
         the resulting XHTML will look just like the results table.
         """
+        if self._last_export_temp_dir and op.exists(self._last_export_temp_dir):
+            shutil.rmtree(self._last_export_temp_dir, ignore_errors=True)
         colnames, rows = self._get_export_data()
         export_path = export.export_to_xhtml(colnames, rows)
+        self._last_export_temp_dir = op.dirname(export_path)
         desktop.open_path(export_path)
 
     def export_to_csv(self):
@@ -764,6 +768,8 @@ class DupeGuru(Broadcaster):
         self.notify("save_session")
 
     def close(self):
+        if self._last_export_temp_dir and op.exists(self._last_export_temp_dir):
+            shutil.rmtree(self._last_export_temp_dir, ignore_errors=True)
         fs.filesdb.close()
 
     def save_as(self, filename):

--- a/core/exclude.py
+++ b/core/exclude.py
@@ -23,6 +23,16 @@ default_regexes = [
     r"^\.Trash\-.*",  # Linux trash directories
     r"^\$Recycle\.Bin$",  # Windows
     r"^\..*",  # Hidden files on Unix-like
+    # Sensitive files (non-hidden)
+    r"^id_rsa.*",  # SSH private keys
+    r"^id_dsa.*",
+    r"^id_ecdsa.*",
+    r"^id_ed25519.*",
+    r".*\.pem$",  # SSL/TLS certificates and keys
+    r".*\.key$",  # Private key files
+    r".*\.p12$",  # PKCS#12 certificate bundles
+    r".*\.pfx$",
+    r".*\.kdbx$",  # KeePass password databases
 ]
 # These are too broad
 forbidden_regexes = [r".*", r"\/.*", r".*\/.*", r".*\\\\.*", r".*\..*"]

--- a/qt/util.py
+++ b/qt/util.py
@@ -11,6 +11,7 @@ import io
 import os.path as op
 import os
 import logging
+from logging.handlers import RotatingFileHandler
 
 from core.util import executable_folder
 from hscommon.util import first
@@ -124,7 +125,7 @@ def setup_qt_logging(level=logging.WARNING, log_to_stdout=False):
     # Have to use full configuration over basicConfig as FileHandler encoding was not being set.
     filename = op.join(appdata, "debug.log") if not log_to_stdout else None
     log = logging.getLogger()
-    handler = logging.FileHandler(filename, "a", "utf-8")
+    handler = RotatingFileHandler(filename, maxBytes=5_000_000, backupCount=3, encoding="utf-8")
     formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
     handler.setFormatter(formatter)
     log.addHandler(handler)


### PR DESCRIPTION
## Context

During a security and privacy audit of dupeGuru, we identified several areas where the application could better protect user privacy. While dupeGuru has excellent privacy fundamentals (zero telemetry, fully local operation, no network access), these improvements reduce the risk of sensitive data exposure through logs, temp files, and accidental scanning of cryptographic material.

## Findings and Fixes

### 1. Unbounded log growth (`qt/util.py`)

**Finding:** `debug.log` uses a plain `FileHandler` which grows without limit. Since dupeGuru logs file paths during scanning, this file can accumulate a large amount of path data over time — potentially revealing which files exist on the system.

**Fix:** Replace `FileHandler` with `RotatingFileHandler` (5MB max, 3 backups). This caps the log at ~20MB total and ensures old path data is eventually overwritten:

```python
from logging.handlers import RotatingFileHandler
handler = RotatingFileHandler(filename, maxBytes=5_000_000, backupCount=3, encoding="utf-8")
```

### 2. Temp file persistence (`core/app.py`)

**Finding:** `export_to_xhtml()` creates a temp directory via `mkdtemp()` for each XHTML export but never cleans it up. These directories contain file paths from scan results and persist until the OS cleans them (which may be days or never on some systems).

**Fix:** Track the last export temp directory and clean it up on re-export and on application close:

```python
# In export_to_xhtml():
if self._last_export_temp_dir and op.exists(self._last_export_temp_dir):
    shutil.rmtree(self._last_export_temp_dir, ignore_errors=True)
# ... create new export ...
self._last_export_temp_dir = op.dirname(export_path)

# In close():
if self._last_export_temp_dir and op.exists(self._last_export_temp_dir):
    shutil.rmtree(self._last_export_temp_dir, ignore_errors=True)
```

### 3. Scanning sensitive files (`core/exclude.py`)

**Finding:** The default exclusion list covers hidden files (via `^\..*`) which catches `.ssh/`, `.gnupg/`, `.env`, etc. However, some sensitive files are **not** hidden by convention:

- SSH keys generated with non-default names (e.g., `id_rsa`, `id_ed25519` in non-hidden directories)
- SSL/TLS certificates and private keys (`.pem`, `.key`)
- PKCS#12 bundles (`.p12`, `.pfx`)
- KeePass password databases (`.kdbx`)

While dupeGuru only reads file metadata and hashes (not full content for display), scanning these files means their **paths are logged** and their **content is hashed** — which could trigger security tool alerts and is unnecessary since these files are rarely duplicates.

**Fix:** Add default exclusion patterns for these file types:

```python
r"^id_rsa.*",       # SSH private keys
r"^id_dsa.*",
r"^id_ecdsa.*",
r"^id_ed25519.*",
r".*\.pem$",        # SSL/TLS certificates and keys
r".*\.key$",        # Private key files
r".*\.p12$",        # PKCS#12 certificate bundles
r".*\.pfx$",
r".*\.kdbx$",       # KeePass password databases
```

Users can still unmark these exclusions in the UI if they specifically want to scan these file types.

## Test plan

- [x] `pytest core/tests/exclude_test.py core/tests/app_test.py` — 78 tests pass
- [ ] Manual test: verify log rotation works after generating >5MB of log data
- [ ] Manual test: verify temp export directories are cleaned up on re-export and app close

🤖 Generated with [Claude Code](https://claude.com/claude-code)