### PR TITLE
Add StartupWMClass to desktop files to ensure DupeGuru icon is shown in

### DIFF
--- a/pkg/arch/dupeguru.desktop
+++ b/pkg/arch/dupeguru.desktop
@@ -6,3 +6,4 @@ Icon={iconpath}
 Terminal=false
 Type=Application
 Categories=Utility;
+StartupWMClass=dupeguru

--- a/pkg/debian/dupeguru.desktop
+++ b/pkg/debian/dupeguru.desktop
@@ -6,3 +6,4 @@ Icon={iconpath}
 Terminal=false
 Type=Application
 Categories=Utility;
+StartupWMClass=dupeguru

--- a/pkg/dupeguru.desktop
+++ b/pkg/dupeguru.desktop
@@ -7,3 +7,4 @@ Terminal=false
 Type=Application
 Categories=Utility;
 Keywords=file manager;gui;
+StartupWMClass=dupeguru


### PR DESCRIPTION
Add StartupWMClass to desktop files to ensure DupeGuru icon is shown in
launcher. Background:
https://specifications.freedesktop.org/desktop-entry/latest/recognized-keys.html#StartupWMClass
https://discussion.fedoraproject.org/t/how-to-ensure-a-launcher-icon-gets-linked-to-the-application-it-launches/67688
https://askubuntu.com/questions/1553339/launch-icon-displays-config-icon-rather-than-specific-icon
