### PR TITLE
Set the application DesktopFileName

### DIFF
--- a/run.py
+++ b/run.py
@@ -48,6 +48,7 @@ def setup_signals():
 
 def main():
     app = QApplication(sys.argv)
+    app.setDesktopFileName("dupeguru")
     QCoreApplication.setOrganizationName("Hardcoded Software")
     QCoreApplication.setApplicationName(__appname__)
     QCoreApplication.setApplicationVersion(__version__)


### PR DESCRIPTION
This sets the desktop filename so the application name in the dock is "dupeguru" instead of just "python3".

See also:
https://github.com/qutebrowser/qutebrowser/pull/4153/files
https://tickets.metabrainz.org/browse/PICARD-1502
https://github.com/arsenetar/dupeguru/pull/1390