### PR TITLE
core: guard copy_or_move when no location path matches dupe parent

### DIFF
--- a/core/app.py
+++ b/core/app.py
@@ -433,7 +433,7 @@ class DupeGuru(Broadcaster):
         if dest_type in {DestType.RELATIVE, DestType.ABSOLUTE}:
             # no filename, no windows drive letter
             source_base = source_path.relative_to(source_path.anchor).parent
-            if dest_type == DestType.RELATIVE:
+            if dest_type == DestType.RELATIVE and location_path is not None:
                 source_base = source_base.relative_to(location_path.relative_to(location_path.anchor))
             dest_path = dest_path.joinpath(source_base)
         if not dest_path.exists():

--- a/core/tests/app_test.py
+++ b/core/tests/app_test.py
@@ -90,6 +90,26 @@ class TestCaseDupeGuru:
         eq_(1, len(calls))
         eq_(sourcepath, calls[0]["path"])
 
+    def test_copy_or_move_no_location_path(self, tmpdir, monkeypatch):
+        # dupe path has no parent in self.directories (e.g. directory removed
+        # between scan and copy); previously raised AttributeError on None
+        p = Path(str(tmpdir))
+        p.joinpath("foo").touch()
+        monkeypatch.setattr(
+            hscommon.conflict,
+            "smart_copy",
+            log_calls(lambda source_path, dest_path: None),
+        )
+        monkeypatch.setattr(app, "smart_copy", hscommon.conflict.smart_copy)
+        monkeypatch.setattr(os, "makedirs", lambda path: None)
+        dgapp = TestApp().app
+        dgapp.directories.add_path(p)
+        [f] = dgapp.directories.get_files()
+        dgapp.directories._dirs.clear()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            dgapp.copy_or_move(f, True, tmp_dir, 1)
+            eq_(1, len(hscommon.conflict.smart_copy.calls))
+
     def test_scan_with_objects_evaluating_to_false(self):
         class FakeFile(fs.File):
             def __bool__(self):


### PR DESCRIPTION
Fixes #1334.

`copy_or_move` uses `first()` to find the directory that contains the dupe; when no parent matches it returns `None`. With `DestType.RELATIVE` the next line called `location_path.relative_to(...)` on that `None`, producing the `AttributeError: 'NoneType' object has no attribute 'relative_to'` in the issue.

Skip the relative rebase when there is no matching location path; the dest path falls back to the absolute layout. Added a test that drops the directory list between scan and copy to cover the path.