### PR TITLE
fix: Don't crash on startup when a saved folder is unreachable

### DIFF
--- a/core/app.py
+++ b/core/app.py
@@ -380,6 +380,13 @@ class DupeGuru(Broadcaster):
             self.notify("directories_changed")
         except directories.AlreadyThereError:
             self.view.show_message(tr("'{}' already is in the list.").format(d))
+        except directories.UnreachablePathError:
+            self.view.show_message(
+                tr(
+                    "'{}' could not be read. It might be on a disconnected network share, "
+                    "or you might not have the permission to access it."
+                ).format(d)
+            )
         except directories.InvalidPathError:
             self.view.show_message(tr("'{}' does not exist.").format(d))
 

--- a/core/directories.py
+++ b/core/directories.py
@@ -20,6 +20,7 @@ __all__ = [
     "DirectoryState",
     "AlreadyThereError",
     "InvalidPathError",
+    "UnreachablePathError",
 ]
 
 
@@ -42,6 +43,14 @@ class AlreadyThereError(Exception):
 
 class InvalidPathError(Exception):
     """The path being added is invalid"""
+
+
+class UnreachablePathError(InvalidPathError):
+    """The path being added can't be probed at all
+
+    We don't know whether it exists: it might be a disconnected network share, or a folder
+    we don't have the permission to access.
+    """
 
 
 class Directories:
@@ -151,14 +160,21 @@ class Directories:
         Raises :exc:`AlreadyThereError` if ``path`` is already in self. If path is a directory
         containing some of the directories already present in self, ``path`` will be added, but all
         directories under it will be removed. Can also raise :exc:`InvalidPathError` if ``path``
-        does not exist.
+        does not exist, or its :exc:`UnreachablePathError` subclass if we can't even tell whether
+        it exists.
 
         :param Path path: path to add
         """
         if path in self:
             raise AlreadyThereError()
-        if not path.exists():
-            raise InvalidPathError()
+        try:
+            if not path.exists():
+                raise InvalidPathError(f"'{path}' does not exist")
+        except OSError as e:
+            # Path.exists() only swallows a handful of "not found" errors. Anything else
+            # (unreachable network share, unauthenticated SMB guest access, permission
+            # denied, ...) propagates and would otherwise crash our callers.
+            raise UnreachablePathError(f"'{path}' could not be probed: {e}") from e
         self._dirs = [p for p in self._dirs if path not in p.parents]
         self._dirs.append(path)
 
@@ -256,8 +272,15 @@ class Directories:
             path = attrib["path"]
             try:
                 self.add_path(Path(path))
-            except (AlreadyThereError, InvalidPathError):
-                pass
+            except AlreadyThereError:
+                # Not a failure: the file we're loading has both a folder and one of its
+                # subfolders in it, and add_path() legitimately keeps only the parent.
+                logging.debug("Directory %s is already covered by another one", path)
+            except (InvalidPathError, OSError, ValueError) as e:
+                # Don't let a folder that became unavailable since the last session
+                # (unplugged drive, disconnected network share, malformed path, ...)
+                # prevent the rest of the selection from loading.
+                logging.warning("Could not load directory %s from the last session: %s", path, e)
         for sn in root.iter("state"):
             attrib = sn.attrib
             if not ("path" in attrib and "value" in attrib):

--- a/core/tests/directories_test.py
+++ b/core/tests/directories_test.py
@@ -20,6 +20,7 @@ from core.directories import (
     DirectoryState,
     AlreadyThereError,
     InvalidPathError,
+    UnreachablePathError,
 )
 from core.exclude import ExcludeList, ExcludeDict
 
@@ -242,6 +243,46 @@ def test_invalid_path():
     with raises(InvalidPathError):
         d.add_path(p)
     eq_(0, len(d))
+
+
+def test_add_path_when_path_cannot_be_probed(monkeypatch):
+    """A path we can't even probe (disconnected network share, unauthenticated SMB guest access, ...) makes
+    Path.exists() raise OSError instead of returning False. We don't want that error to escape add_path()."""
+
+    def exists(self, *args, **kwargs):
+        raise OSError(1272, "You can't access this shared folder")
+
+    monkeypatch.setattr(Path, "exists", exists)
+    d = Directories()
+    with raises(UnreachablePathError):
+        d.add_path(Path("foo_bar"))
+    eq_(0, len(d))
+
+
+def test_load_from_file_with_unprobable_path(tmpdir, monkeypatch):
+    """An unavailable folder in the saved selection must not prevent the other ones from being loaded (it used
+    to crash the app on startup)."""
+    p1 = Path(str(tmpdir.join("p1")))
+    p1.mkdir()
+    unreachable = Path(str(tmpdir.join("unreachable")))
+    d1 = Directories()
+    d1.add_path(p1)
+    d1._dirs.append(unreachable)
+    tmpxml = str(tmpdir.join("directories_testunit.xml"))
+    d1.save_to_file(tmpxml)
+
+    real_exists = Path.exists
+
+    def exists(self, *args, **kwargs):
+        if self == unreachable:
+            raise OSError(1272, "You can't access this shared folder")
+        return real_exists(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "exists", exists)
+    d2 = Directories()
+    d2.load_from_file(tmpxml)
+    eq_(1, len(d2))
+    eq_(p1, d2[0])
 
 
 def test_set_state_on_invalid_path():


### PR DESCRIPTION
### Problem

`Path.exists()` only swallows a handful of "not found" errnos (`ENOENT`, `ENOTDIR`, `EBADF`, `ELOOP`). Any other `OSError` propagates.

`Directories.add_path()` called it bare, and `load_from_file()` only caught `AlreadyThereError` and `InvalidPathError`. When a folder saved in `last_directories.xml` has become unreachable since the last session, the `OSError` escapes all the way out of `DupeGuru.load()` during `qt.app._setup()` (before any window exists). The user gets a "Failed to execute script 'run' due to unhandled exception" dialog whose only button is Close, and the app is unusable until the folder comes back or the file is edited by hand.

This has been reported in #1391 (network share, `WinError 1326`) and #1149 (unmounted BitLocker volume). Reproduced here with `WinError 1272`, SMB guest access blocked by policy:

```
Traceback (most recent call last):
  File "run.py", line 88, in <module>
  File "run.py", line 75, in main
  File "qt\app.py", line 56, in __init__
  File "qt\app.py", line 101, in _setup
  File "core\app.py", line 573, in load
  File "core\directories.py", line 257, in load_from_file
  File "core\directories.py", line 159, in add_path
  File "pathlib.py", line 1407, in exists
  File "pathlib.py", line 1198, in stat
OSError: [WinError 1272] You can't access this shared folder because your
organization's security policies block unauthenticated guest access: '\server\share\folder'
```

The three error codes above are all the same bug: the specific errno doesn't particularly matter, only that it isn't one of the four `Path.exists()` ignores.

### Changes

- Add `UnreachablePathError`, a subclass of `InvalidPathError`, for a path that cannot be probed at all, since we do not know whether it exists. Since it is a subclass, existing code that catches `InvalidPathError` keeps working unchanged.
- `add_path()` raises it instead of letting the `OSError` escape.
- `add_directory()` tells the user the folder could not be read, and why it might have happened, instead of "does not exist"
- `load_from_file()` skips any entry it cannot restore and logs the reason, rather than aborting the rest of the selection. `AlreadyThereError` is logged at debug level there, since it is the expected outcome when the saved file holds both a folder and one of its subfolders.

An unavailable folder is dropped from the saved selection rather than shown as unavailable in the folder list. #1391 asks for the latter, but that needs changes to `Directories` and the folder tree model, so would have been a much more ambitious change and it seems better to keep this intentionally narrow in scope.

### Tests

Two regression tests in `core/tests/directories_test.py` causes `Path.exists` to raise `OSError`, covering both code paths: `add_path()` raising `UnreachablePathError`, and `load_from_file()` continuing past the bad entry to load the remaining folders. Both fail without the fix.

Verified locally with the versions this repo pins: `pre-commit run` (black 24.2.0, flake8 7.0.0) and `pytest core/tests/directories_test.py hscommon`. The rest of `core` needs `build.py --modules`, which CI runs.

Closes #1391
Closes #1149
