### PR TITLE
Only treat files as hardlinks when the device matches too

### DIFF
--- a/core/app.py
+++ b/core/app.py
@@ -335,10 +335,14 @@ class DupeGuru(Broadcaster):
         result = []
         for file in files:
             try:
-                inode = file.path.stat().st_ino
+                stats = file.path.stat()
             except OSError:
                 # The file was probably deleted or something
                 continue
+            # An inode number is only unique within its filesystem, so two files on
+            # different devices can share one without being hardlinks. Keying on the
+            # inode alone dropped those from the scan.
+            inode = (stats.st_dev, stats.st_ino)
             if inode not in seen_inodes:
                 seen_inodes.add(inode)
                 result.append(file)

--- a/core/tests/app_test.py
+++ b/core/tests/app_test.py
@@ -117,6 +117,37 @@ class TestCaseDupeGuru:
         app.start_scanning()
         eq_(len(app.results.groups), 0)
 
+    def test_hardlink_dupes_are_keyed_on_device_as_well_as_inode(self):
+        # Issue #1388. An inode number is only unique within one filesystem, so two
+        # unrelated files on different devices can share one. Keying the seen set on
+        # the inode alone dropped the second file from the scan entirely, which made
+        # results shrink on every rescan.
+        class FakeStat:
+            def __init__(self, dev, ino):
+                self.st_dev = dev
+                self.st_ino = ino
+
+        class FakePath:
+            def __init__(self, dev, ino):
+                self._stat = FakeStat(dev, ino)
+
+            def stat(self):
+                return self._stat
+
+        class FakeEntry:
+            def __init__(self, dev, ino):
+                self.path = FakePath(dev, ino)
+
+        # Same inode, different devices: not hardlinks, so both are kept.
+        on_disk_a = FakeEntry(1, 42)
+        on_disk_b = FakeEntry(2, 42)
+        eq_(app.DupeGuru._remove_hardlink_dupes([on_disk_a, on_disk_b]), [on_disk_a, on_disk_b])
+
+        # Same device and inode: a real hardlink, so only the first is kept.
+        first = FakeEntry(1, 42)
+        second = FakeEntry(1, 42)
+        eq_(app.DupeGuru._remove_hardlink_dupes([first, second]), [first])
+
     def test_rename_when_nothing_is_selected(self):
         # Issue #140
         # It's possible that rename operation has its selected row swept off from under it, thus


### PR DESCRIPTION
Closes #1388.

`_remove_hardlink_dupes` built its seen set from `st_ino` alone:

```python
inode = file.path.stat().st_ino
if inode not in seen_inodes:
```

An inode number is only unique within one filesystem, so two unrelated files on different devices can share one. With `ignore_hardlink_matches` on and directories from more than one drive in the scan, the second file was discarded before `get_dupe_groups` ever saw it.

That also explains the shrinking-results symptom in the report rather than just the missing matches: the file that *was* reported got deleted, so on the next scan a different member of the inode collision won, and a further set of real duplicates surfaced — a few fewer each run.

The fix keys on `(st_dev, st_ino)`, which is what actually identifies a hardlink.

### Verified

The cross-device case cannot be produced from a temp directory, so the regression test drives the static method directly with controlled `st_dev`/`st_ino`, covering both directions — same inode on different devices (both kept) and same inode on the same device (deduplicated).

- Red before green: with the test in place and `core/app.py` stashed, `test_hardlink_dupes_are_keyed_on_device_as_well_as_inode` fails with the second entry missing; restored, it passes.
- The existing `test_ignore_hardlink_matches` (real `os.link`, same device) still passes, so genuine hardlinks are unaffected.
- `pytest core/tests/` — 388 passed, 24 failed. The same 24 fail on pristine `master` here: this machine has no MSVC toolchain, so `core.pe._block` / `core.pe._cache` are stubbed to let the suite import. Baseline is 387 passed / 24 failed, so this change adds one passing test and moves nothing else.
