### PR TITLE
fix: Report a problem instead of crashing on relative copy/move

### DIFF
--- a/core/app.py
+++ b/core/app.py
@@ -43,6 +43,7 @@ DEBUG_MODE_PREFERENCE = "DebugMode"
 
 MSG_NO_MARKED_DUPES = tr("There are no marked duplicates. Nothing has been done.")
 MSG_NO_SELECTED_DUPES = tr("There are no selected duplicates. Nothing has been done.")
+MSG_NOT_IN_DIRECTORIES = tr("The file is not under any folder in the Directories panel. Can't recreate relative path.")
 MSG_MANY_FILES_TO_OPEN = tr(
     "You're about to open many files at once. Depending on what those "
     "files are opened with, doing so can create quite a mess. Continue?"
@@ -434,6 +435,10 @@ class DupeGuru(Broadcaster):
             # no filename, no windows drive letter
             source_base = source_path.relative_to(source_path.anchor).parent
             if dest_type == DestType.RELATIVE:
+                if location_path is None:
+                    # The dupe isn't under any folder in the Directories panel (e.g. results were loaded from a
+                    # file after the folder list changed), so there's no root to make the path relative to.
+                    raise OSError(MSG_NOT_IN_DIRECTORIES)
                 source_base = source_base.relative_to(location_path.relative_to(location_path.anchor))
             dest_path = dest_path.joinpath(source_base)
         if not dest_path.exists():

--- a/core/tests/app_test.py
+++ b/core/tests/app_test.py
@@ -76,6 +76,21 @@ class TestCaseDupeGuru:
             eq_(call["dest_path"], Path(tmp_dir, "foo"))
             eq_(call["source_path"], f.path)
 
+    def test_copy_or_move_relative_outside_directories(self, tmpdir, monkeypatch):
+        # A dupe loaded from a results file can live outside every folder in the Directories panel.
+        # Recreating its relative path is then impossible: report a problem for that dupe instead of
+        # crashing the whole job (#1334, #1352).
+        p = Path(str(tmpdir))
+        p.joinpath("foo").touch()
+        monkeypatch.setattr(app, "smart_copy", log_calls(lambda source_path, dest_path: None))
+        dgapp = TestApp().app
+        f = fs.File(p.joinpath("foo"))
+        dest = p.joinpath("dest")
+        with pytest.raises(OSError):
+            dgapp.copy_or_move(f, True, str(dest), app.DestType.RELATIVE)
+        eq_(0, len(app.smart_copy.calls))
+        assert not dest.exists()
+
     def test_copy_or_move_clean_empty_dirs(self, tmpdir, monkeypatch):
         tmppath = Path(str(tmpdir))
         sourcepath = tmppath.joinpath("source")


### PR DESCRIPTION
When "Recreate relative path" is selected and a marked dupe isn't under any folder in the Directories panel (typically after loading results from a file once the folder list has changed), copy_or_move() dereferenced a None location_path and the whole job aborted with
"'NoneType' object has no attribute 'relative_to'".

Raise an OSError instead so perform_on_marked() records the dupe in the problem list and the user sees it in the problem dialog, while the other marked files are still processed.

Fixes #1334, fixes #1352